### PR TITLE
Feature/User Auth and Database Integration

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -8,6 +8,7 @@ User.init(
     id: {
       type: DataTypes.STRING,
       allowNull: false,
+      unique: true,
       primaryKey: true,
       comment: 'Unique identifier for the user',
     },
@@ -19,7 +20,7 @@ User.init(
           msg: 'Name cannot be null.',
         },
         notEmpty: {
-          msg: 'ame cannot be empty.',
+          msg: 'Name cannot be empty.',
         },
         len: {
           args: [1, 50],

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,36 +79,8 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-<<<<<<< HEAD
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@eslint/eslintrc/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
-=======
-            }
-        },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/@eslint/js": {
             "version": "8.57.0",
             "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
@@ -118,8 +90,6 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/@hapi/hoek": {
             "version": "9.3.0",
             "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -133,7 +103,6 @@
                 "@hapi/hoek": "^9.0.0"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.14",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -146,36 +115,8 @@
             },
             "engines": {
                 "node": ">=10.10.0"
-<<<<<<< HEAD
             }
         },
-        "node_modules/@humanwhocodes/config-array/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@humanwhocodes/config-array/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
-=======
-            }
-        },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/@humanwhocodes/module-importer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
@@ -195,8 +136,6 @@
             "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
             "dev": true
         },
-<<<<<<< HEAD
-=======
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
             "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -222,6 +161,27 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+        },
+        "node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
@@ -271,7 +231,6 @@
                 "node": ">=6"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -307,8 +266,6 @@
                 "node": ">= 8"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/@panva/asn1.js": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
@@ -377,7 +334,6 @@
                 "@types/responselike": "^1.0.0"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/@types/debug": {
             "version": "4.1.12",
             "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -386,8 +342,6 @@
                 "@types/ms": "*"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/@types/http-cache-semantics": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -401,7 +355,6 @@
                 "@types/node": "*"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/@types/ms": {
             "version": "0.7.34",
             "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
@@ -415,8 +368,6 @@
                 "undici-types": "~5.26.4"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/@types/responselike": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
@@ -425,7 +376,6 @@
                 "@types/node": "*"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/@types/validator": {
             "version": "13.11.9",
             "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.9.tgz",
@@ -437,14 +387,11 @@
             "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
             "dev": true
         },
-<<<<<<< HEAD
-=======
         "node_modules/abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/accepts": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -478,8 +425,6 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/agent-base": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -503,7 +448,6 @@
                 "node": ">=8"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/ajv": {
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -524,10 +468,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "engines": {
                 "node": ">=8"
             }
@@ -536,10 +476,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -550,8 +486,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/anymatch": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -581,7 +515,6 @@
                 "node": ">=10"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -598,8 +531,6 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
-<<<<<<< HEAD
-=======
         "node_modules/base64url": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
@@ -629,7 +560,6 @@
                 "node": ">=8"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/body-parser": {
             "version": "1.20.2",
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
@@ -653,8 +583,6 @@
                 "npm": "1.2.8000 || >= 1.4.16"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/body-parser/node_modules/debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -668,22 +596,15 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/braces": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -695,7 +616,6 @@
                 "node": ">=8"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/bytes": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -704,8 +624,6 @@
                 "node": ">= 0.8"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/cacheable-lookup": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
@@ -731,7 +649,6 @@
                 "node": ">=8"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/call-bind": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -775,8 +692,6 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/chokidar": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -846,15 +761,10 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -867,8 +777,6 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
-<<<<<<< HEAD
-=======
         "node_modules/color-support": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
@@ -877,14 +785,11 @@
                 "color-support": "bin.js"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
         },
-<<<<<<< HEAD
-=======
         "node_modules/connect-session-sequelize": {
             "version": "7.1.7",
             "resolved": "https://registry.npmjs.org/connect-session-sequelize/-/connect-session-sequelize-7.1.7.tgz",
@@ -904,7 +809,6 @@
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/content-disposition": {
             "version": "0.5.4",
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -941,10 +845,6 @@
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
             "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -955,15 +855,6 @@
             }
         },
         "node_modules/debug": {
-<<<<<<< HEAD
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-=======
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
@@ -1004,15 +895,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
         },
-<<<<<<< HEAD
-=======
         "node_modules/defer-to-connect": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
@@ -1021,7 +909,6 @@
                 "node": ">=10"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/define-data-property": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -1038,14 +925,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/delegates": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
             "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/denque": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
@@ -1071,8 +955,6 @@
                 "npm": "1.2.8000 || >= 1.4.16"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/detect-libc": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
@@ -1081,7 +963,6 @@
                 "node": ">=8"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/doctrine": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1110,27 +991,21 @@
             "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.6.tgz",
             "integrity": "sha512-iGCHkfUc5kFekGiqhe8B/mdaurD+lakO9txNnTvKtA6PISrw86LgqHvRzWYPyoE2Ph5aMIrCw9/uko6XHTKCwA=="
         },
-<<<<<<< HEAD
-=======
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
         },
-<<<<<<< HEAD
-=======
         "node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/encodeurl": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -1139,8 +1014,6 @@
                 "node": ">= 0.8"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/end-of-stream": {
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -1149,7 +1022,6 @@
                 "once": "^1.4.0"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/es-define-property": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
@@ -1268,32 +1140,6 @@
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
-<<<<<<< HEAD
-        },
-        "node_modules/eslint/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/eslint/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         },
         "node_modules/espree": {
             "version": "9.6.1",
@@ -1403,8 +1249,6 @@
                 "node": ">= 0.10.0"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/express-handlebars": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/express-handlebars/-/express-handlebars-7.1.2.tgz",
@@ -1573,7 +1417,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1613,8 +1456,6 @@
                 "node": "^10.12.0 || >=12.0.0"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/fill-range": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1626,7 +1467,6 @@
                 "node": ">=8"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/finalhandler": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -1644,8 +1484,6 @@
                 "node": ">= 0.8"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/finalhandler/node_modules/debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1659,7 +1497,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/find-up": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -1696,8 +1533,6 @@
             "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
             "dev": true
         },
-<<<<<<< HEAD
-=======
         "node_modules/foreground-child": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
@@ -1713,7 +1548,17 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
+        "node_modules/foreground-child/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/forwarded": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1730,8 +1575,6 @@
                 "node": ">= 0.6"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/fs-minipass": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -1754,28 +1597,11 @@
                 "node": ">=8"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
         },
-<<<<<<< HEAD
-=======
-        "node_modules/fsevents": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1784,8 +1610,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/futoin-hkdf": {
             "version": "1.5.3",
             "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.5.3.tgz",
@@ -1813,30 +1637,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/gauge/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "node_modules/gauge/node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-        },
-        "node_modules/gauge/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/generate-function": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
@@ -1863,8 +1663,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/get-stream": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -1879,15 +1677,10 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -1941,8 +1734,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/got": {
             "version": "11.8.6",
             "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
@@ -1972,7 +1763,6 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/graphemer": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2041,14 +1831,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/has-unicode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
             "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/hasown": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
@@ -2060,14 +1847,11 @@
                 "node": ">= 0.4"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/http-cache-semantics": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
             "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/http-errors": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -2083,8 +1867,6 @@
                 "node": ">= 0.8"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/http2-wrapper": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
@@ -2109,7 +1891,6 @@
                 "node": ">= 6"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -2130,14 +1911,11 @@
                 "node": ">= 4"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/ignore-by-default": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
             "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -2163,8 +1941,6 @@
                 "node": ">=0.8.19"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/indent-string": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -2173,7 +1949,6 @@
                 "node": ">=8"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/inflection": {
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.4.tgz",
@@ -2186,10 +1961,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -2208,8 +1979,6 @@
                 "node": ">= 0.10"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2221,21 +1990,14 @@
                 "node": ">=8"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "engines": {
                 "node": ">=0.10.0"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2244,15 +2006,10 @@
                 "node": ">=8"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/is-glob": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -2260,8 +2017,6 @@
                 "node": ">=0.10.0"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2270,7 +2025,6 @@
                 "node": ">=0.12.0"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/is-path-inside": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -2290,8 +2044,6 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
         },
-<<<<<<< HEAD
-=======
         "node_modules/jackspeak": {
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
@@ -2335,7 +2087,6 @@
                 "url": "https://github.com/sponsors/panva"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/js-yaml": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2369,10 +2120,6 @@
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
@@ -2421,8 +2168,6 @@
             "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
             "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
         },
-<<<<<<< HEAD
-=======
         "node_modules/lowercase-keys": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -2431,7 +2176,6 @@
                 "node": ">=8"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/lru-cache": {
             "version": "8.0.5",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
@@ -2440,8 +2184,6 @@
                 "node": ">=16.14"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -2469,7 +2211,6 @@
             "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
             "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -2521,8 +2262,6 @@
                 "node": ">= 0.6"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/mimic-response": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
@@ -2531,15 +2270,10 @@
                 "node": ">=4"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -2555,14 +2289,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/minipass": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-            "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": ">=8"
             }
         },
         "node_modules/minizlib": {
@@ -2599,7 +2331,6 @@
                 "node": ">=10"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/moment": {
             "version": "2.30.1",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -2620,15 +2351,9 @@
             }
         },
         "node_modules/ms": {
-<<<<<<< HEAD
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-=======
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         },
         "node_modules/mysql2": {
             "version": "3.9.2",
@@ -2697,8 +2422,6 @@
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
         },
-<<<<<<< HEAD
-=======
         "node_modules/node-addon-api": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
@@ -2829,7 +2552,6 @@
                 "node": ">= 6"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/object-inspect": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
@@ -2838,8 +2560,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/oidc-token-hash": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
@@ -2848,7 +2568,6 @@
                 "node": "^10.13.0 || >=12.0.0"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/on-finished": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -2860,8 +2579,6 @@
                 "node": ">= 0.8"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/on-headers": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
@@ -2870,21 +2587,14 @@
                 "node": ">= 0.8"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "dependencies": {
                 "wrappy": "1"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/openid-client": {
             "version": "4.9.1",
             "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-4.9.1.tgz",
@@ -2916,7 +2626,6 @@
                 "node": ">=10"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/optionator": {
             "version": "0.9.3",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -2934,8 +2643,6 @@
                 "node": ">= 0.8.0"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/p-cancelable": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
@@ -2944,7 +2651,6 @@
                 "node": ">=8"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -3008,10 +2714,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3020,16 +2722,10 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "engines": {
                 "node": ">=8"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/path-scurry": {
             "version": "1.10.1",
             "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
@@ -3053,7 +2749,6 @@
                 "node": "14 || >=16.14"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/path-to-regexp": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -3064,8 +2759,6 @@
             "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
             "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="
         },
-<<<<<<< HEAD
-=======
         "node_modules/picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -3077,7 +2770,6 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3099,8 +2791,6 @@
                 "node": ">= 0.10"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/pstree.remy": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -3115,7 +2805,6 @@
                 "once": "^1.3.1"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3159,8 +2848,6 @@
                 }
             ]
         },
-<<<<<<< HEAD
-=======
         "node_modules/quick-lru": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -3180,7 +2867,6 @@
                 "node": ">= 0.8"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/range-parser": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -3203,8 +2889,6 @@
                 "node": ">= 0.8"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/readable-stream": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -3234,7 +2918,6 @@
             "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
             "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3244,8 +2927,6 @@
                 "node": ">=4"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/responselike": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
@@ -3257,7 +2938,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/retry-as-promised": {
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
@@ -3277,10 +2957,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -3386,8 +3062,6 @@
                 "node": ">= 0.8.0"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/send/node_modules/debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -3401,7 +3075,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/send/node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3481,30 +3154,6 @@
                 "node": ">= 10.0.0"
             }
         },
-<<<<<<< HEAD
-        "node_modules/sequelize/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/sequelize/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/serve-static": {
             "version": "1.15.0",
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
@@ -3519,14 +3168,11 @@
                 "node": ">= 0.8.0"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/set-function-length": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
@@ -3552,10 +3198,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -3567,10 +3209,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "engines": {
                 "node": ">=8"
             }
@@ -3592,18 +3230,10 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/signal-exit": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
         },
         "node_modules/simple-update-notifier": {
             "version": "2.0.0",
@@ -3616,7 +3246,6 @@
                 "node": ">=10"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3641,8 +3270,6 @@
                 "node": ">= 0.8"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/string_decoder": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -3652,19 +3279,16 @@
             }
         },
         "node_modules/string-width": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
             },
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/string-width-cjs": {
@@ -3681,45 +3305,10 @@
                 "node": ">=8"
             }
         },
-        "node_modules/string-width-cjs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "node_modules/string-width/node_modules/ansi-regex": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/string-width/node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -3727,8 +3316,6 @@
                 "node": ">=8"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/strip-ansi-cjs": {
             "name": "strip-ansi",
             "version": "6.0.1",
@@ -3741,7 +3328,6 @@
                 "node": ">=8"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3766,8 +3352,6 @@
                 "node": ">=8"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/tar": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
@@ -3784,23 +3368,12 @@
                 "node": ">=10"
             }
         },
-        "node_modules/tar/node_modules/minipass": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true
         },
-<<<<<<< HEAD
-=======
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3812,7 +3385,6 @@
                 "node": ">=8.0"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/toidentifier": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -3826,8 +3398,6 @@
             "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
             "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg=="
         },
-<<<<<<< HEAD
-=======
         "node_modules/touch": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -3844,7 +3414,6 @@
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3893,8 +3462,6 @@
                 "node": ">=0.8.0"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/uid-safe": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -3911,7 +3478,6 @@
             "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
             "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/undici-types": {
             "version": "5.26.5",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -3934,8 +3500,6 @@
                 "punycode": "^2.1.0"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/url-join": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -3946,7 +3510,6 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/utils-merge": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -3979,8 +3542,6 @@
                 "node": ">= 0.8"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -3995,15 +3556,10 @@
                 "webidl-conversions": "^3.0.0"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -4014,8 +3570,6 @@
                 "node": ">= 8"
             }
         },
-<<<<<<< HEAD
-=======
         "node_modules/wide-align": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -4024,25 +3578,6 @@
                 "string-width": "^1.0.2 || 2 || 3 || 4"
             }
         },
-        "node_modules/wide-align/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "node_modules/wide-align/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/wkx": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
@@ -4056,8 +3591,6 @@
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
             "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
         },
-<<<<<<< HEAD
-=======
         "node_modules/wrap-ansi": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -4091,24 +3624,6 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
-        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/wrap-ansi/node_modules/ansi-regex": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -4131,6 +3646,27 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/wrap-ansi/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+        },
+        "node_modules/wrap-ansi/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/wrap-ansi/node_modules/strip-ansi": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -4145,7 +3681,6 @@
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
->>>>>>> ef9b8274c4fb459e527f37a35bfdba4d0dcbc3a1
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",

--- a/proto.js
+++ b/proto.js
@@ -2,7 +2,9 @@
 /* This is a prototype script for Passwordless Auth, please do not under any circumstances use this file in any production capacity */
 const express = require('express');
 // Auth is required to initialise the connection to Auth0, requiresAuth is needed to add a hook to pages that require login
-const { auth, requiresAuth } = require('express-openid-connect');
+// We're renaming this to oidcAuth so we can substitute with our own custom middleware implementation
+const { auth } = require('express-openid-connect');
+const requiresAuth = require('./utils/auth.js');
 const session = require('express-session'); // Maybe not needed after all?
 const config = require('./config/auth.js');
 const db = require('./config/connection.js');
@@ -22,23 +24,6 @@ app.use(session({
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-async function checkUser(req, res, next) {
-    if (req.oidc.isAuthenticated()) {
-        await User.findOrCreate({
-            where: {
-                id: req.oidc.user.sub
-            }, 
-            defaults: {
-                id: req.oidc.user.sub,
-                name: req.oidc.user.nickname,
-                timezone_id: 1
-            }
-        });
-    }
-
-    next();
-}
-
 app.get('/', (req, res) => {
     res.json({
         isLoggedIn: req.oidc.isAuthenticated(), // oidc helper that returns a bool if logged in
@@ -47,7 +32,7 @@ app.get('/', (req, res) => {
     });
 });
 
-app.get('/test', requiresAuth(), checkUser, async (req, res) => {
+app.get('/test', requiresAuth(), async (req, res) => {
     const userEntry = await User.findOne({ where: { id: req.oidc.user.sub } });
     const responseMsg = {
         auth0: Object.assign(req.oidc.user),
@@ -56,7 +41,7 @@ app.get('/test', requiresAuth(), checkUser, async (req, res) => {
     res.json(responseMsg);
 });
 
-db.sync({force: true}).then(() => {
+db.sync({alter: true}).then(() => {
     app.listen(PORT, () => {
         console.log(`Listening on port ${PORT}`);
     });

--- a/proto.js
+++ b/proto.js
@@ -3,9 +3,10 @@
 const express = require('express');
 // Auth is required to initialise the connection to Auth0, requiresAuth is needed to add a hook to pages that require login
 const { auth, requiresAuth } = require('express-openid-connect');
-const session = require('express-session');
+const session = require('express-session'); // Maybe not needed after all?
 const config = require('./config/auth.js');
-const User = require('./models/user.js');
+const db = require('./config/connection.js');
+const { User } = require('./models');
 
 const PORT = process.env.DEV_PORT;
 const app = express();
@@ -24,12 +25,14 @@ app.use(express.urlencoded({ extended: true }));
 async function checkUser(req, res, next) {
     if (req.oidc.isAuthenticated()) {
         await User.findOrCreate({
-            id: req.oidc.user.sub,
-            userName: req.oidc.user.nickname,
-            email: req.oidc.user.email
-        },
-        {
-            id: req.oidc.user.sub
+            where: {
+                id: req.oidc.user.sub
+            }, 
+            defaults: {
+                id: req.oidc.user.sub,
+                name: req.oidc.user.nickname,
+                timezone_id: 1
+            }
         });
     }
 
@@ -44,10 +47,17 @@ app.get('/', (req, res) => {
     });
 });
 
-app.get('/test', requiresAuth(), checkUser, (req, res) => {
-    res.json(req.oidc.user); // oidc.user contains the profile data fetched from an authenticated account
+app.get('/test', requiresAuth(), checkUser, async (req, res) => {
+    const userEntry = await User.findOne({ where: { id: req.oidc.user.sub } });
+    const responseMsg = {
+        auth0: Object.assign(req.oidc.user),
+        db: userEntry ? userEntry : {}
+    }
+    res.json(responseMsg);
 });
 
-app.listen(PORT, () => {
-    console.log(`Listening on port ${PORT}`);
+db.sync({force: true}).then(() => {
+    app.listen(PORT, () => {
+        console.log(`Listening on port ${PORT}`);
+    });
 });

--- a/proto.js
+++ b/proto.js
@@ -3,7 +3,9 @@
 const express = require('express');
 // Auth is required to initialise the connection to Auth0, requiresAuth is needed to add a hook to pages that require login
 const { auth, requiresAuth } = require('express-openid-connect');
+const session = require('express-session');
 const config = require('./config/auth.js');
+const User = require('./models/user.js');
 
 const PORT = process.env.DEV_PORT;
 const app = express();
@@ -11,8 +13,28 @@ const app = express();
 // Initialise Auth0 integration and load config
 // Automatically establishes endpoints for /login /logout /callback (which passes on requests to Auth0)
 app.use(auth(config));
+app.use(session({
+    secret: process.env.AUTH_SECRET,
+    resave: false,
+    saveUninitialized: true
+}));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+
+async function checkUser(req, res, next) {
+    if (req.oidc.isAuthenticated()) {
+        await User.findOrCreate({
+            id: req.oidc.user.sub,
+            userName: req.oidc.user.nickname,
+            email: req.oidc.user.email
+        },
+        {
+            id: req.oidc.user.sub
+        });
+    }
+
+    next();
+}
 
 app.get('/', (req, res) => {
     res.json({
@@ -22,7 +44,7 @@ app.get('/', (req, res) => {
     });
 });
 
-app.get('/test', requiresAuth(), (req, res) => {
+app.get('/test', requiresAuth(), checkUser, (req, res) => {
     res.json(req.oidc.user); // oidc.user contains the profile data fetched from an authenticated account
 });
 

--- a/seeds/eventData.json
+++ b/seeds/eventData.json
@@ -10,7 +10,7 @@
     "platform_id": 1,
     "min_player": 2,
     "max_player": 10,
-    "organizer_id": 1
+    "organizer_id": "email|6C6F6C6C6D616F726F666C6D"
   },
   {
     "status_id": 1,
@@ -23,6 +23,6 @@
     "platform_id": 1,
     "min_player": 2,
     "max_player": 10,
-    "organizer_id": 1
+    "organizer_id": "email|6C6F6C6C6D616F726F666C6D"
   }
 ]

--- a/seeds/userData.json
+++ b/seeds/userData.json
@@ -1,13 +1,13 @@
 [
   {
-    "id": "1",
-    "name": "Doe",
+    "id": "email|6C6F6C6C6D616F726F666C6D",
+    "name": "John D",
     "timezone_id": 1,
     "active": true
   },
   {
-    "id": "2",
-    "name": "Doe",
+    "id": "email|716272776E66786C7A796467",
+    "name": "Joe B",
     "timezone_id": 1,
     "active": true
   }

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -19,7 +19,7 @@ function requiresAuth() {
                             defaults: {
                                 id: req.oidc.user.sub,
                                 name: req.oidc.user.nickname,
-                                timezone_id: 1
+                                timezone_id: 1 // TODO: Update to use chronofixer function instead
                             }
                         });
                 } catch (error) {

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -1,0 +1,36 @@
+/**
+ * This helper substitutes the requiresAuth() function in auth0 to passively incorporate a check to create an equivalent entry in the database (if one doesn't exist already)
+ */
+// Import user model and original requiresAuth function for our helper
+const { requiresAuth: oidcAuth } = require('express-openid-connect');
+const { User } = require('../models');
+
+function requiresAuth() {
+    // Because a function is required instead of a promise, we have to wrap the code for the middleware inside this block
+    return (req, res, next) => {
+        // The output of oidcAuth() is intercepted and passed through a function block that acts as though it's another middleware
+        oidcAuth()(req, res, async () => {
+            if (req.oidc.isAuthenticated()) {
+                try {
+                        await User.findOrCreate({
+                            where: {
+                                id: req.oidc.user.sub
+                            }, 
+                            defaults: {
+                                id: req.oidc.user.sub,
+                                name: req.oidc.user.nickname,
+                                timezone_id: 1
+                            }
+                        });
+                } catch (error) {
+                    console.error('Error in checkUser:', error);
+                    return res.status(500).json({message: "Internal server error."});
+                }
+            }
+
+            next();
+        });
+    };
+}
+
+module.exports = requiresAuth;


### PR DESCRIPTION
Integration of Auth0 support has been added in the form of a modified requiresAuth() helper function.

How to use it:
- Import from `./utils/auth.js` instead of from `express-openid-connect`
```js
const { auth } = require('express-openid-connect');
const requiresAuth = require('./utils/auth.js');
```
- All functions using requiresAuth() now inherit the new functionality implicitly
- Apply to all route files using requiresAuth() as appropriate.

How it works:
- Executes the original requiresAuth() middleware as normal
- The output is then intercepted by our function, which we then use to perform the required check, and instantiate a new user as required
- The output is then passed on to the next middleware, and then returns the function so it passes type checking.